### PR TITLE
Scala Pair and Map support

### DIFF
--- a/src/main/scala/com/spotify/sprunch/Examples.scala
+++ b/src/main/scala/com/spotify/sprunch/Examples.scala
@@ -19,8 +19,6 @@ object Examples {
             .map{case ((country, artist), plays) =>
               new CountryArtistPlays(country, artist, plays)}
 
-
-
   /** Sum the total plays for each country using CountryArtistPlays as a starting point */
   def sumPlaysByCountry(records: PCollection[CountryArtistPlays]) =
     records.mapToTable(rec => (rec.getCountry, rec.getPlays))

--- a/src/main/scala/com/spotify/sprunch/Examples.scala
+++ b/src/main/scala/com/spotify/sprunch/Examples.scala
@@ -1,9 +1,6 @@
 package com.spotify.sprunch
 
-
-import scala.collection.JavaConverters._
-
-import org.apache.crunch.{PCollection, Pair=>CPair}
+import org.apache.crunch.PCollection
 import Sprunch.Upgrades._
 import Sprunch.Avro._
 import com.spotify.example.records.{CountryArtistPlays, TrackPlayedMessage}
@@ -13,22 +10,23 @@ object Examples {
   def wordCount(lines: PCollection[String]) =
     lines.flatMap(_.split("\\s+"))
          .count()
-         .map(wordCount => wordCount.first() + ":" + wordCount.second())
+         .map{case (word, count) => word + ":" + count}
 
   /** Count the number of plays for each distinct pair of userCountry and artistName */
   def countryArtistPlays(messages: PCollection[TrackPlayedMessage]) =
-    messages.map(msg => CPair.of(msg.getUserCountry, msg.getArtistName))
+    messages.map(msg => (msg.getUserCountry, msg.getArtistName))
             .count()
-            .map(rec => new CountryArtistPlays(rec.first().first(),
-                                               rec.first().second(),
-                                               rec.second()))
+            .map{case ((country, artist), plays) =>
+              new CountryArtistPlays(country, artist, plays)}
+
+
 
   /** Sum the total plays for each country using CountryArtistPlays as a starting point */
   def sumPlaysByCountry(records: PCollection[CountryArtistPlays]) =
     records.mapToTable(rec => (rec.getCountry, rec.getPlays))
            .groupByKey()
            .foldValues(0L, _+_)
-           .map(countryPlays => countryPlays.first() + ":" + countryPlays.second())
+           .map{case (country, plays) => country + ":" + plays}
 
   /** Output all TrackPlayedMessages for which userCountry="SE" and duration > 30 seconds */
   def filterTrackPlayedMessages(message: PCollection[TrackPlayedMessage]) =
@@ -36,6 +34,6 @@ object Examples {
 
   /** Map-typed output example */
   def mapTypedOutput(message: PCollection[TrackPlayedMessage]) =
-    message.map(m => Map("artist" -> m.getArtistName, "duration" -> m.getDurationMs.toString).asJava)
+    message.map(m => Map("artist" -> m.getArtistName, "duration" -> m.getDurationMs.toString))
 
 }

--- a/src/main/scala/com/spotify/sprunch/Sprunch.scala
+++ b/src/main/scala/com/spotify/sprunch/Sprunch.scala
@@ -36,6 +36,11 @@ object Sprunch {
     def filterBy(acceptFn: T => Boolean) = underlying.filter(new Fns.SFilter(acceptFn))
   }
 
+  /** Sprunch extensions for an underlying PCollection */
+  class STable[K, V](val underlying: PTable[K, V]) {
+    /** Allow expressing map on PTable as a binary function instead of a function of CPairs */
+    def map[U](fn: (K, V) => U)(implicit pType: PType[U]) = underlying.parallelDo(new Fns.SPairMap(fn), pType)
+  }
 
   /** Sprunch extensions for an underlying PGroupedTable */
   class SGroupedTable[K, V](val underlying: PGroupedTable[K, V]) {
@@ -49,7 +54,9 @@ object Sprunch {
    */
   object Upgrades {
     implicit def upgrade[T](collection: PCollection[T]): SCollection[T] = new SCollection[T](collection)
+    implicit def upgrade[K, V](table: PTable[K, V]): STable[K, V] = new STable[K, V](table)
     implicit def upgrade[K, V](table: PGroupedTable[K, V]): SGroupedTable[K, V] = new SGroupedTable[K, V](table)
+
   }
 
   /**
@@ -84,6 +91,21 @@ object Sprunch {
     implicit def maps[V](implicit pType: PType[V]): PType[JMap[String, V]] = Avros.maps(pType)
     implicit def collections[T](implicit pType: PType[T]): PType[java.util.Collection[T]] = Avros.collections(pType)
     implicit def tableOf[K, V](implicit keyType: PType[K], valueType: PType[V]): PTableType[K, V] = Avros.tableOf(keyType, valueType)
+
+    implicit def scalaPairs[T1, T2](implicit pType1: PType[T1], pType2: PType[T2]): PType[Pair[T1, T2]] =
+      Avros.derived(
+        classOf[Pair[T1,T2]],
+        new Fns.SMap[CPair[T1, T2], Pair[T1, T2]](TypeConversions.toSPair),
+        new Fns.SMap[Pair[T1, T2], CPair[T1, T2]](TypeConversions.toCPair),
+        pairs(pType1, pType2))
+
+    implicit def scalaMap[V](implicit pType: PType[V]): PType[Map[String, V]] =
+      Avros.derived(
+        classOf[Map[String, V]],
+        new Fns.SMap[JMap[String, V], Map[String, V]](_.asScala.toMap), // NOTE: This will copy the map, ie. _expensive_
+        new Fns.SMap[Map[String, V], JMap[String, V]](_.asJava),
+        maps(pType)
+      )
   }
 
   /**
@@ -104,6 +126,11 @@ object Sprunch {
     /** Wrap simple function into MapFn */
     class SMap[T, U](fn: T=>U) extends MapFn[T, U] {
       override def map(input: T) = fn(input)
+    }
+
+    /** Wrap Scala pair-parametered function into a MapFn accepting a CPair */
+    class SPairMap[K, V, U](fn: (K, V) => U) extends MapFn[CPair[K, V], U] {
+      override def map(input: CPair[K, V]): U = fn(input.first(), input.second())
     }
 
     /** Wrap Scala pair-valued function into a MapFn suitable for creating a PTable */

--- a/src/main/scala/com/spotify/sprunch/Sprunch.scala
+++ b/src/main/scala/com/spotify/sprunch/Sprunch.scala
@@ -37,7 +37,7 @@ object Sprunch {
   }
 
   /** Sprunch extensions for an underlying PCollection */
-  class STable[K, V](val underlying: PTable[K, V]) {
+  class STable[K, V](val underlying: PCollection[CPair[K, V]]) {
     /** Allow expressing map on PTable as a binary function instead of a function of CPairs */
     def map[U](fn: (K, V) => U)(implicit pType: PType[U]) = underlying.parallelDo(new Fns.SPairMap(fn), pType)
   }
@@ -54,7 +54,7 @@ object Sprunch {
    */
   object Upgrades {
     implicit def upgrade[T](collection: PCollection[T]): SCollection[T] = new SCollection[T](collection)
-    implicit def upgrade[K, V](table: PTable[K, V]): STable[K, V] = new STable[K, V](table)
+    implicit def upgrade[K, V](table: PCollection[CPair[K, V]]): STable[K, V] = new STable[K, V](table)
     implicit def upgrade[K, V](table: PGroupedTable[K, V]): SGroupedTable[K, V] = new SGroupedTable[K, V](table)
 
   }

--- a/src/test/scala/com/spotify/sprunch/ExamplesTest.scala
+++ b/src/test/scala/com/spotify/sprunch/ExamplesTest.scala
@@ -78,7 +78,7 @@ class ExamplesTest {
       MemPipeline.typedCollectionOf(Avros.specifics(classOf[TrackPlayedMessage]),
         new TrackPlayedMessage("trk", "Heretics", "UK", 10000))).materialize()
 
-    Assert.assertEquals(Map("artist"->"Heretics", "duration"->"10000").asJava, output.iterator().next())
+    Assert.assertEquals(Map("artist"->"Heretics", "duration"->"10000"), output.iterator().next())
 
   }
 }


### PR DESCRIPTION
Support for Scala pair PType inference and using binary functions to map from PTables. This makes the use of pairs more intuitive and makes destructuring via case in functions possible.

Also support for Scala Map PTypes, but because by default Scala maps are immutable, it many generate many unnecessary copies in practice. You have been warned.
